### PR TITLE
Change value type from string to text

### DIFF
--- a/database/migrations/2017_03_03_100000_create_options_table.php
+++ b/database/migrations/2017_03_03_100000_create_options_table.php
@@ -16,7 +16,7 @@ class CreateOptionsTable extends Migration
         Schema::create('options', function (Blueprint $table) {
             $table->increments('id');
             $table->string('key');
-            $table->string('value');
+            $table->text('value');
         });
     }
 


### PR DESCRIPTION
I can use options package in almost all of my projects in many ways, but with that, it would create an issue for some situations where I will need more than default 255 chars for value. So by converting value string to text. It will give quite a room for use in different kinds of situations. 


