### PR TITLE
Add unique constraint to `key` field in database

### DIFF
--- a/database/migrations/2017_03_03_100000_create_options_table.php
+++ b/database/migrations/2017_03_03_100000_create_options_table.php
@@ -15,7 +15,7 @@ class CreateOptionsTable extends Migration
     {
         Schema::create('options', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('key');
+            $table->string('key')->unique();
             $table->text('value');
         });
     }


### PR DESCRIPTION
This will prevent duplicate keys and speed up queries.