### PR TITLE
Remove automatic migration registration

### DIFF
--- a/src/OptionsServiceProvider.php
+++ b/src/OptionsServiceProvider.php
@@ -22,9 +22,6 @@ class OptionsServiceProvider extends ServiceProvider
                 \Appstract\Options\Console\OptionSetCommand::class,
             ]);
         }
-
-        // Register migrations
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     }
 
     /**


### PR DESCRIPTION
Since migrations are provided by publishing, auto-registration like this can cause conflicts with customized migrations.