### PR TITLE
Update 2017_03_03_100000_create_options_table.php

### DIFF
--- a/database/migrations/2017_03_03_100000_create_options_table.php
+++ b/database/migrations/2017_03_03_100000_create_options_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Facades\Schema;
 
 class CreateOptionsTable extends Migration
@@ -16,7 +17,7 @@ class CreateOptionsTable extends Migration
         Schema::create('options', function (Blueprint $table) {
             $table->increments('id');
             $table->string('key')->unique();
-            $table->json('value');
+            $table->json('value')->default(new Expression('(JSON_ARRAY())'));
         });
     }
 


### PR DESCRIPTION
Using an Expression instance will prevent wrapping the value in quotes and allow you to use database specific functions. One situation where this is particularly useful is when you need to assign default values to JSON columns: