### PR TITLE
Improvements and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,14 @@ With the `option()` helper, we can get and set options:
 option('someKey');
 
 // Get option, with a default fallback value if the key doesn't exist
+// If option value is encrypted, automatically decrypt before return value
 option('someKey', 'Some default value if the key is not found');
 
 // Set option
 option(['someKey' => 'someValue']);
+
+// Set option and encrypt value
+option(['someKey' => 'someValueToEncrypt'])->crypt();
 
 // Remove option
 option()->remove('someKey');
@@ -55,6 +59,8 @@ It is also possible to set options within the console:
 ```bash
 php artisan option:set {someKey} {someValue}
 ```
+
+Optionally you can dd `--crypt` option to encrypt value.
 
 ## Testing
 

--- a/src/Console/OptionSetCommand.php
+++ b/src/Console/OptionSetCommand.php
@@ -14,7 +14,8 @@ class OptionSetCommand extends Command
      */
     protected $signature = 'option:set
                             {key : Option key}
-                            {value : Option value}';
+                            {value : Option value}
+                            {--crypt : Encrypt option value (optional)}';
 
     /**
      * The console command description.
@@ -30,7 +31,11 @@ class OptionSetCommand extends Command
      */
     public function handle()
     {
-        Option::set($this->argument('key'), $this->argument('value'));
+        $option = Option::set($this->argument('key'), $this->argument('value'));
+
+        if ($this->option('crypt')) {
+            $option->crypt();
+        }
 
         $this->info('Option added.');
     }

--- a/src/Option.php
+++ b/src/Option.php
@@ -3,6 +3,7 @@
 namespace Appstract\Options;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Encryption\DecryptException;
 
 class Option extends Model
 {
@@ -25,9 +26,19 @@ class Option extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var [type]
+     * @var array
      */
     protected $fillable = [
+        'key',
+        'value',
+    ];
+
+    /**
+     * The attributes that are visible.
+     *
+     * @var array
+     */
+    protected $visible = [
         'key',
         'value',
     ];
@@ -53,7 +64,9 @@ class Option extends Model
     public function get($key, $default = null)
     {
         if ($option = self::where('key', $key)->first()) {
-            return $option->value;
+            $value = $option->encrypted() ? decrypt($option->value) : $option->value;
+
+            return is_array($value) ? (object) $value : $value;
         }
 
         return $default;
@@ -64,17 +77,17 @@ class Option extends Model
      *
      * @param  array|string  $key
      * @param  mixed  $value
-     * @return void
+     * @return \Appstract\Options\Option
      */
     public function set($key, $value = null)
     {
         $keys = is_array($key) ? $key : [$key => $value];
 
         foreach ($keys as $key => $value) {
-            self::updateOrCreate(['key' => $key], ['value' => $value]);
+            $option = self::updateOrCreate(['key' => $key], ['value' => $value]);
         }
 
-        // @todo: return the option
+        return $option;
     }
 
     /**
@@ -86,5 +99,32 @@ class Option extends Model
     public function remove($key)
     {
         return (bool) self::where('key', $key)->delete();
+    }
+
+    /**
+     * Encrypt option value after set() is called.
+     * 
+     * @return \Appstract\Options\Option
+     */
+    public function crypt()
+    {
+        self::where('key', $this->key)
+            ->update(['value' => json_encode(encrypt($this->value))]);
+
+        return $this;
+    }
+
+    /**
+     * Determine if the option value is encrypted.
+     * 
+     * @return bool
+     */
+    public function encrypted()
+    {
+        try {
+            return (bool) decrypt($this->value);
+        } catch (DecryptException $e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
- Possible to encrypt option value adding `->crypt()`.
- If a value option is encrypted, return automatically decrypted value.
- If a value is an array, it behaves like an object: each value can be retrieved with a `->` (for example: `option('user')->first_name`).
- Artisan command: possible to add `--crypt` option to encrypt value.
- README updated.